### PR TITLE
Change order of v3-attributes

### DIFF
--- a/v3.c
+++ b/v3.c
@@ -121,8 +121,8 @@ static void v3_sendattrs(struct sftpjob *job, const struct sftpattr *attrs) {
       fatal("sending out-of-range mtime");
     if(a != attrs->atime.seconds)
       fatal("sending out-of-range mtime");
-    sftp_send_uint32(job->worker, m);
     sftp_send_uint32(job->worker, a);
+    sftp_send_uint32(job->worker, m);
   }
   /* Note that we just discard unknown bits rather than reporting errors. */
 }


### PR DESCRIPTION
atime- and mtime-attributes need to be swapped on v3 according to https://tools.ietf.org/html/draft-ietf-secsh-filexfer-00. Current order creates unexpected behavior when using OpenSSH sftp "ls -l" compared to "ls -n".